### PR TITLE
Поддержка транзакций

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.jupiter-tools</groupId>
     <artifactId>spring-test-mongo</artifactId>
-    <version>0.14</version>
+    <version>0.15</version>
     <packaging>jar</packaging>
 
     <name>spring-test-mongo</name>

--- a/src/main/java/com/jupiter/tools/spring/test/mongo/internal/expect/MatchDataSets.java
+++ b/src/main/java/com/jupiter/tools/spring/test/mongo/internal/expect/MatchDataSets.java
@@ -39,8 +39,8 @@ public class MatchDataSets {
         Map<String, List<Map<String, Object>>> patternMap = pattern.read();
         Map<String, List<Map<String, Object>>> matchedMap = matched.read();
 
-        assertSetsOfDocumentsAreIdentical(matchedMap.keySet(),
-                                          patternMap.keySet());
+        assertMatchedCollectionsAllContainsInPattern(matchedMap.keySet(),
+                                                     patternMap.keySet());
 
         patternMap.keySet().forEach(documentName -> {
             checkOneCollection(documentName, matchedMap.get(documentName), patternMap.get(documentName));
@@ -70,12 +70,14 @@ public class MatchDataSets {
                 .isEqualTo(pattern.size());
     }
 
-    private void assertSetsOfDocumentsAreIdentical(Set<String> documentNamesFirst,
-                                                   Set<String> documentNamesSecond) {
-        Assertions.assertEquals(documentNamesFirst,
-                                documentNamesSecond,
-                                () -> String.format("Not equal document collections:\n expected:\n[%s],\n actual: \n[%s]",
-                                                    documentNamesFirst.stream().collect(Collectors.joining(", ")),
-                                                    documentNamesSecond.stream().collect(Collectors.joining(", "))));
+    private void assertMatchedCollectionsAllContainsInPattern(Set<String> matched,
+                                                              Set<String> pattern) {
+        Set<String> notFoundCollections = pattern.stream()
+                                                 .filter(collection -> !matched.contains(collection))
+                                                 .collect(Collectors.toSet());
+
+        Assertions.assertTrue(notFoundCollections.isEmpty(),
+                              () -> String.format("Not equal document collections:\n expected but not found:\n[%s]",
+                                                  String.join(", ", notFoundCollections)));
     }
 }

--- a/src/main/java/com/jupiter/tools/spring/test/mongo/junit5/MongoDbExtension.java
+++ b/src/main/java/com/jupiter/tools/spring/test/mongo/junit5/MongoDbExtension.java
@@ -9,6 +9,7 @@ import com.jupiter.tools.spring.test.mongo.errorinfo.MongoDbErrorInfo;
 import com.jupiter.tools.spring.test.mongo.internal.MongoDbTest;
 import org.junit.jupiter.api.extension.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.File;
@@ -93,7 +94,7 @@ public class MongoDbExtension implements Extension, BeforeAllCallback, BeforeEac
             try {
                 new MongoDbTest(mongoTemplate).expect(filePath);
             } catch (Error e) {
-                throw new RuntimeException("Expected ReadOnly dataset, but found some modifications:",e);
+                throw new RuntimeException("Expected ReadOnly dataset, but found some modifications:", e);
             }
             return;
         }
@@ -136,7 +137,7 @@ public class MongoDbExtension implements Extension, BeforeAllCallback, BeforeEac
      */
     private void cleanDataBase() {
         mongoTemplate.getCollectionNames()
-                     .forEach(mongoTemplate::dropCollection);
+                     .forEach(collectionName -> mongoTemplate.remove(new Query(), collectionName));
     }
 
     private boolean isReadOnlyDataSet(ExtensionContext context) {

--- a/src/main/java/com/jupiter/tools/spring/test/mongo/junit5/MongoDbTcExtension.java
+++ b/src/main/java/com/jupiter/tools/spring/test/mongo/junit5/MongoDbTcExtension.java
@@ -1,7 +1,14 @@
 package com.jupiter.tools.spring.test.mongo.junit5;
 
+import com.antkorwin.commonutils.exceptions.InternalException;
 import org.junit.jupiter.api.extension.Extension;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.builder.Transferable;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Created on 02.12.2018.
@@ -16,12 +23,27 @@ public class MongoDbTcExtension implements Extension {
         System.out.println("Start MongoDb testcontainers extension...\n");
 
         GenericContainer mongo = new GenericContainer("mongo:latest")
+                .withCommand("mongod --bind_ip_all --replSet rs0")
                 .withExposedPorts(MONGO_PORT);
 
         mongo.start();
 
+        executeInContainer(mongo, "mongo --eval \"rs.initiate()\"");
+
         System.setProperty("spring.data.mongodb.host", mongo.getContainerIpAddress());
         System.setProperty("spring.data.mongodb.port", mongo.getMappedPort(MONGO_PORT).toString());
+        System.setProperty("spring.data.mongodb.replicaSet", "rs0");
     }
 
+    private static void executeInContainer(GenericContainer container, String command) {
+        byte[] contentBytes = command.getBytes(UTF_8);
+        String shellFilePath = "/etc/mongo-" + UUID.randomUUID().toString();
+
+        try {
+            container.copyFileToContainer(Transferable.of(contentBytes), shellFilePath);
+            container.execInContainer("/bin/bash", shellFilePath);
+        } catch (Exception exc) {
+            throw new InternalException(exc);
+        }
+    }
 }

--- a/src/test/java/com/jupiter/tools/spring/test/mongo/internal/MongoDbTestExpectedIT.java
+++ b/src/test/java/com/jupiter/tools/spring/test/mongo/internal/MongoDbTestExpectedIT.java
@@ -1,10 +1,5 @@
 package com.jupiter.tools.spring.test.mongo.internal;
 
-import java.util.Arrays;
-import java.util.Date;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-
 import com.jupiter.tools.spring.test.mongo.Bar;
 import com.jupiter.tools.spring.test.mongo.FloatHolder;
 import com.jupiter.tools.spring.test.mongo.Foo;
@@ -15,11 +10,15 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -88,7 +87,7 @@ class MongoDbTestExpectedIT {
         Error error = Assertions.assertThrows(Error.class, () -> {
             new MongoDbTest(mongoTemplate).expect("/dataset/internal/expected_dataset.json");
         });
-        assertThat(error.getMessage()).contains("Not equal document collections");
+        assertThat(error.getMessage()).contains("expected 2 but found 0 - com.jupiter.tools.spring.test.mongo.Bar entities");
     }
 
     @Test
@@ -174,15 +173,12 @@ class MongoDbTestExpectedIT {
         mongoTemplate.save(bar2);
         // Act
         Error error = Assertions.assertThrows(Error.class, () -> {
-            new MongoDbTest(mongoTemplate).expect("/dataset/internal/expected_dataset_multiple.json");
+            new MongoDbTest(mongoTemplate).expect("/dataset/internal/expected_dataset_not_exists_collection.json");
         });
 
         assertThat(error.getMessage()).contains("Not equal document collections")
-                                      .contains("expected:\n[com.jupiter.tools.spring.test.mongo.Bar]")
-                                      .contains("actual: \n[com.jupiter.tools.spring.test.mongo.Bar," +
-                                                " com.jupiter.tools.spring.test.mongo.Foo]");
+                                      .contains("expected but not found:\n[com.jupiter.tools.spring.test.mongo.Boo]");
     }
-
 
     @Nested
     @SpringBootTest

--- a/src/test/java/com/jupiter/tools/spring/test/mongo/junit5/MongoDbExtensionCleanAfterIT.java
+++ b/src/test/java/com/jupiter/tools/spring/test/mongo/junit5/MongoDbExtensionCleanAfterIT.java
@@ -3,12 +3,16 @@ package com.jupiter.tools.spring.test.mongo.junit5;
 import com.jupiter.tools.spring.test.mongo.Bar;
 import com.jupiter.tools.spring.test.mongo.annotation.MongoDataSet;
 import com.jupiter.tools.spring.test.mongo.internal.MongoDbTest;
+import com.mongodb.client.MongoCollection;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,7 +45,13 @@ class MongoDbExtensionCleanAfterIT {
             MongoTemplate mongoTemplate = SpringExtension.getApplicationContext(context)
                                                          .getBean(MongoTemplate.class);
 
-            assertThat(mongoTemplate.getCollectionNames().size()).isEqualTo(0);
+            Set<Long> documentCount = mongoTemplate.getCollectionNames()
+                                             .stream()
+                                             .map(mongoTemplate::getCollection)
+                                             .map(MongoCollection::countDocuments)
+                                             .collect(Collectors.toSet());
+
+            assertThat(documentCount).containsOnly(0L);
         }
     }
 }

--- a/src/test/java/com/jupiter/tools/spring/test/mongo/junit5/MongoDbExtensionCleanBeforeIT.java
+++ b/src/test/java/com/jupiter/tools/spring/test/mongo/junit5/MongoDbExtensionCleanBeforeIT.java
@@ -3,6 +3,8 @@ package com.jupiter.tools.spring.test.mongo.junit5;
 import com.jupiter.tools.spring.test.mongo.Bar;
 import com.jupiter.tools.spring.test.mongo.annotation.MongoDataSet;
 import com.jupiter.tools.spring.test.mongo.internal.MongoDbTest;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,7 +46,10 @@ class MongoDbExtensionCleanBeforeIT {
         Bar simpleDoc = mongoTemplate.findById("55f3ed00b1375a48e61830bf", Bar.class);
         assertThat(simpleDoc).isNull();
 
-        assertThat(mongoTemplate.getCollectionNames().size()).isEqualTo(0);
+        String collectionName = mongoTemplate.getCollectionName(Bar.class);
+        MongoCollection<Document> collection = mongoTemplate.getCollection(collectionName);
+
+        assertThat(collection.countDocuments()).isEqualTo(0L);
     }
 
     public static class TestExtension implements Extension, BeforeEachCallback {

--- a/src/test/java/com/jupiter/tools/spring/test/mongo/junit5/MongoDbTcExtensionIT.java
+++ b/src/test/java/com/jupiter/tools/spring/test/mongo/junit5/MongoDbTcExtensionIT.java
@@ -1,0 +1,159 @@
+package com.jupiter.tools.spring.test.mongo.junit5;
+
+import com.jupiter.tools.spring.test.mongo.Foo;
+import com.jupiter.tools.spring.test.mongo.annotation.MongoDataSet;
+import com.jupiter.tools.spring.test.mongo.internal.exportdata.scanner.ReflectionsDocumentScanner;
+import com.jupiter.tools.spring.test.mongo.junit5.MongoDbTcExtensionIT.MongoTransactionTestConfig;
+import com.jupiter.tools.spring.test.mongo.junit5.MongoDbTcExtensionIT.MongoTransactionTestConfig.TransactionalExecutor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@ExtendWith(MongoDbExtension.class)
+@Import(MongoTransactionTestConfig.class)
+@EnableMongoDbTestContainers
+class MongoDbTcExtensionIT {
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoTransactionManager transactionManager;
+
+    @Autowired
+    private TransactionalExecutor transactionalExecutor;
+
+    @Test
+    @MongoDataSet(cleanBefore = true, cleanAfter = true)
+    void saveWithExceptionTest() {
+        // Arrange
+        assertFooCollectionEmpty();
+
+        // Act
+        assertThrows(
+                RuntimeException.class,
+                () -> {
+                    mongoTemplate.save(new Foo());
+                    throw new RuntimeException("Some error");
+                });
+
+        // Assert
+        assertFooCollectionNotEmpty();
+    }
+
+    @Test
+    @MongoDataSet(cleanBefore = true, cleanAfter = true)
+    void saveWithExceptionInManualTransactionTest() {
+        // Arrange
+        assertFooCollectionEmpty();
+
+        // Act
+        assertThrows(
+                RuntimeException.class,
+                () -> doInTransaction(
+                        () -> {
+                            mongoTemplate.save(new Foo());
+
+                            throw new RuntimeException("Some error");
+                        }));
+
+        // Assert
+        assertFooCollectionEmpty();
+    }
+
+    @Test
+    @MongoDataSet(cleanBefore = true, cleanAfter = true)
+    void saveWithExceptionInAnnotateTransactionTest() {
+        // Arrange
+        assertFooCollectionEmpty();
+
+        // Act
+        assertThrows(
+                RuntimeException.class,
+                () -> transactionalExecutor.doInTransaction(
+                        () -> {
+                            mongoTemplate.save(new Foo());
+
+                            throw new RuntimeException("Some error");
+                        }));
+
+        // Assert
+        assertFooCollectionEmpty();
+    }
+
+    private void assertFooCollectionEmpty() {
+        List<Foo> after = mongoTemplate.findAll(Foo.class);
+        assertThat(after).isEmpty();
+    }
+
+    private void assertFooCollectionNotEmpty() {
+        List<Foo> after = mongoTemplate.findAll(Foo.class);
+        assertThat(after).isNotEmpty();
+    }
+
+    private void doInTransaction(Runnable runnable) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
+                runnable.run();
+            }
+        });
+    }
+
+    public static class MongoTransactionTestConfig {
+
+        public static class TransactionalExecutor {
+
+            @Transactional
+            public void doInTransaction(Runnable runnable) {
+                runnable.run();
+            }
+        }
+
+        @Bean
+        public TransactionalExecutor transactionalExecutor() {
+            return new TransactionalExecutor();
+        }
+
+        @Bean
+        public MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
+            return new MongoTransactionManager(dbFactory);
+        }
+
+        @Bean
+        public SmartInitializingSingleton createMongoCollectionsOnStartup(MongoTemplate mongoTemplate) {
+
+            return () -> {
+                Map<String, Class<?>> classes = new ReflectionsDocumentScanner("").scan();
+
+                classes.values()
+                       .forEach(clazz -> {
+                           if (!mongoTemplate.collectionExists(clazz)) {
+                               mongoTemplate.createCollection(clazz);
+                           }
+                       });
+            };
+        }
+    }
+}

--- a/src/test/resources/dataset/internal/expected_dataset_not_exists_collection.json
+++ b/src/test/resources/dataset/internal/expected_dataset_not_exists_collection.json
@@ -1,0 +1,24 @@
+{
+  "com.jupiter.tools.spring.test.mongo.Bar": [
+    {
+      "data": "data-1"
+    },
+    {
+      "data": "data-2"
+    }
+  ],
+  "com.jupiter.tools.spring.test.mongo.Boo": [
+    {
+      "id": "F1",
+      "counter": 1
+    },
+    {
+      "id": "F2",
+      "counter": 2
+    },
+    {
+      "id": "F3",
+      "counter": 3
+    }
+  ]
+}


### PR DESCRIPTION
1. Конфигурация контейнера для поддержки транзакций на основе https://www.baeldung.com/spring-data-mongodb-transactions
2. Логика очистки коллекций при работе с дата-сетами (вместо удаления коллекции удаление всех документов в ней). Связано с тем что внутри транзакций коллекции создавать нельзя, поэтому чтобы не получить ошибку при вставке первого документа сами коллекции между тестами должны сохраняться. Подробнее https://stackoverflow.com/a/53501677
3. Логика сравнения списка коллекций в expected дата-сетах. Из-за предыдущего пункта прежняя логика сравнения (список коллекций в базе данных должны соответствовать списку коллекций в json файле) больше не работает. Теперь ошибка генерируется только в том случае если в json файле указаны коллекции которых нет в базе данных