### PR TITLE
Add fix, also fix regexp cast for non string fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.jupiter-tools</groupId>
     <artifactId>spring-test-mongo</artifactId>
-    <version>0.15</version>
+    <version>0.16</version>
     <packaging>jar</packaging>
 
     <name>spring-test-mongo</name>

--- a/src/main/java/com/jupiter/tools/spring/test/mongo/internal/expect/match/smart/regexp/MatchRegExp.java
+++ b/src/main/java/com/jupiter/tools/spring/test/mongo/internal/expect/match/smart/regexp/MatchRegExp.java
@@ -20,7 +20,7 @@ public class MatchRegExp implements MatchDataSmart {
         String cmpValue = (String) comparableValue;
         cmpValue = cmpValue.replaceFirst("regex:", "").trim();
         Pattern pattern = Pattern.compile(cmpValue);
-        Matcher matcher = pattern.matcher((String) originValue);
+        Matcher matcher = pattern.matcher(originValue.toString());
         return matcher.matches();
     }
 

--- a/src/main/java/com/jupiter/tools/spring/test/mongo/internal/exportdata/scanner/CaseInsensitiveMap.java
+++ b/src/main/java/com/jupiter/tools/spring/test/mongo/internal/exportdata/scanner/CaseInsensitiveMap.java
@@ -23,4 +23,9 @@ public class CaseInsensitiveMap extends HashMap<String, Class<?>> {
     public Class<?> get(Object key) {
         return super.get(((String) key).toLowerCase());
     }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return super.containsKey(((String) key).toLowerCase());
+    }
 }

--- a/src/main/java/com/jupiter/tools/spring/test/mongo/internal/exportdata/scanner/DocumentClasses.java
+++ b/src/main/java/com/jupiter/tools/spring/test/mongo/internal/exportdata/scanner/DocumentClasses.java
@@ -24,4 +24,8 @@ public class DocumentClasses {
     public String getDocumentClassName(String collectionName) {
         return documents.get(collectionName).getCanonicalName();
     }
+
+    public boolean hasCollection(String collectionName) {
+        return documents.containsKey(collectionName);
+    }
 }

--- a/src/test/java/com/jupiter/tools/spring/test/mongo/internal/MongoDbTestExpectedIT.java
+++ b/src/test/java/com/jupiter/tools/spring/test/mongo/internal/MongoDbTestExpectedIT.java
@@ -87,7 +87,7 @@ class MongoDbTestExpectedIT {
         Error error = Assertions.assertThrows(Error.class, () -> {
             new MongoDbTest(mongoTemplate).expect("/dataset/internal/expected_dataset.json");
         });
-        assertThat(error.getMessage()).contains("Not equal document collections");
+        assertThat(error.getMessage()).contains("expected 2 but found 0 - com.jupiter.tools.spring.test.mongo.Bar entities");
     }
 
     @Test
@@ -234,6 +234,16 @@ class MongoDbTestExpectedIT {
             mongoTemplate.save(bar4);
             // Act
             new MongoDbTest(mongoTemplate).expect("/dataset/internal/expect/multiple_regex.json");
+        }
+
+        @Test
+        @MongoDataSet(cleanBefore = true, cleanAfter = true)
+        void numberFieldRegexp() {
+            // Arrange
+            Foo foo = new Foo("1", new Date(), 1);
+            mongoTemplate.save(foo);
+            // Act
+            new MongoDbTest(mongoTemplate).expect("/dataset/internal/expect/number_field_regex.json");
         }
     }
 

--- a/src/test/java/com/jupiter/tools/spring/test/mongo/junit4/MongoDbRuleExportDataSetIT.java
+++ b/src/test/java/com/jupiter/tools/spring/test/mongo/junit4/MongoDbRuleExportDataSetIT.java
@@ -8,7 +8,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import com.jupiter.tools.spring.test.mongo.annotation.ExportMongoDataSet;
+import com.jupiter.tools.spring.test.mongo.annotation.MongoDataSet;
 import com.jupiter.tools.spring.test.mongo.internal.MongoDbTest;
+import lombok.Data;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.ClassRule;
@@ -62,6 +64,7 @@ public class MongoDbRuleExportDataSetIT extends BaseMongoIT {
     };
 
     @Test
+    @MongoDataSet(cleanBefore = true, cleanAfter = true)
     @ExportMongoDataSet(outputFile = OUTPUT_FILE_NAME)
     public void testExportDataSet() throws Exception {
         new MongoDbTest(mongoTemplate).importFrom(INPUT_DATA_SET_FILE);

--- a/src/test/resources/dataset/internal/expect/number_field_regex.json
+++ b/src/test/resources/dataset/internal/expect/number_field_regex.json
@@ -1,0 +1,7 @@
+{
+  "com.jupiter.tools.spring.test.mongo.Foo": [
+    {
+      "counter": "regex:.+"
+    }
+  ]
+}


### PR DESCRIPTION
1. Рефлексией не читаются классы отмеченные аннотацией Document если они расположены вне основного пакета (в какой-нибудь библиотеке например). Само по себе не является проблемой, но  приводит к ошибке при сборке датасета для сравнения, коллекция в базе есть, а класс документа не найден, при этом эта коллекция в дата-сетах в принципе не фигурирует
2. Попутно переписал каст при сравнении с регулярным выражением, т.к. для не строковых полей, в частности чисел это приводит к ошибке, хотя технически хочется тоже пользоваться такой возможностью